### PR TITLE
v0.5.0 with environment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.0] 2025-07-15
+
+### Added
+
+- Support configure from environment with env_or(), and recipe::env_logger().
+
+### Changed
+
+- Change recipe raw_file_logger() & raw_file_custom_logger(), user need to specified the full path.
+
+- Change the definition of LogRawFile to support path/str/String/env_or().
+
 ## [0.4.7] 2025-07-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "captains-log"
-version = "0.4.7"
+version = "0.5.0"
 edition = "2024"
 authors = ["plan <frostyplanet@gmail.com>"]
 categories = ["development-tools::debugging"]
@@ -21,7 +21,7 @@ libc = { version= "0" }
 chrono = "0.4"
 parking_lot = "0"
 backtrace = "0.3"
-captains-log-helper = "0.3.0"
+captains-log-helper = "0.3.1"
 exitcode = "1"
 lazy_static = "1.4"
 arc-swap = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,7 +115,7 @@ pub type FormatFunc = fn(FormatRecord) -> String;
 /// Custom formatter which adds into a log sink
 #[derive(Clone, Hash)]
 pub struct LogFormat {
-    time_fmt: String,
+    time_fmt: &'static str,
     format_fn: FormatFunc,
 }
 
@@ -142,13 +142,13 @@ impl LogFormat {
     /// let log_sink = LogRawFile::new("/tmp", "test.log", log::Level::Info, log_format);
     /// ```
 
-    pub fn new(time_fmt: &str, format_fn: FormatFunc) -> Self {
-        Self { time_fmt: time_fmt.to_string(), format_fn }
+    pub const fn new(time_fmt: &'static str, format_fn: FormatFunc) -> Self {
+        Self { time_fmt, format_fn }
     }
 
     #[inline(always)]
     pub(crate) fn process(&self, now: &Timer, record: &Record) -> String {
-        let time = TimeFormatter { now, fmt_str: &self.time_fmt };
+        let time = TimeFormatter { now, fmt_str: self.time_fmt };
         let r = FormatRecord { record, time };
         return (self.format_fn)(r);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,7 +272,17 @@ pub struct EnvVarDefault<'a, T> {
 /// To config some logger setting with env.
 ///
 /// Read value from environment, and set with default if not exists.
+///
 /// NOTE: the arguments to load from env_or() must support owned values.
+///
+/// Example:
+///
+/// ```rust
+/// use captains_log::*;
+/// let _level: log::Level = env_or("LOG_LEVEL", Level::Info).into();
+/// let _file_path: String = env_or("LOG_FILE", "/tmp/test.log").into();
+/// let _console: ConsoleTarget = env_or("LOG_CONSOLE", ConsoleTarget::Stdout).into();
+/// ```
 pub fn env_or<'a, T>(name: &'a str, default: T) -> EnvVarDefault<'a, T> {
     EnvVarDefault { name, default }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6,13 +6,13 @@ use crate::time::Timer;
 
 pub struct TimeFormatter<'a> {
     pub now: &'a Timer,
-    pub fmt_str: &'a String,
+    pub fmt_str: &'a str,
 }
 
 impl<'a> TimeFormatter<'a> {
     #[inline(always)]
     fn time_str(&self) -> String {
-        self.now.format(&self.fmt_str).to_string()
+        self.now.format(self.fmt_str).to_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 //!     let req_id = r.key("req_id");
 //!     format!("[{time}][{level}][{file}:{line}] {msg}{req_id}\n").to_string()
 //! }
-//! let builder = recipe::raw_file_logger_custom("/tmp", "log_filter", log::Level::Debug,
+//! let builder = recipe::raw_file_logger_custom("/tmp/log_filter.log", log::Level::Debug,
 //!     recipe::DEFAULT_TIME, debug_format_req_id_f);
 //! builder.build().expect("setup_log");
 //! let logger = LogFilterKV::new("req_id", format!("{:016x}", 123).to_string());
@@ -168,14 +168,14 @@
 //! #[test]
 //! fn test1() {
 //!     recipe::raw_file_logger(
-//!         "/tmp", "test1.log", Level::Debug).test().build();
+//!         "/tmp/test1.log", Level::Debug).test().build();
 //!     info!("doing test1");
 //! }
 //!
 //! #[test]
 //! fn test2() {
 //!     recipe::raw_file_logger(
-//!         "/tmp", "test2.log", Level::Debug).test().build();
+//!         "/tmp/test2.log", Level::Debug).test().build();
 //!     info!("doing test2");
 //! }
 //! ```
@@ -200,7 +200,7 @@
 //! // In order make logs available.
 //! #[fixture]
 //! fn setup() {
-//!     let builder = recipe::raw_file_logger("/tmp", "log_rstest", log::Level::Debug).test();
+//!     let builder = recipe::raw_file_logger("/tmp/log_rstest.log", log::Level::Debug).test();
 //!     builder.build().expect("setup_log");
 //! }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,15 +39,15 @@
 //! ``` toml
 //! [dependencies]
 //! log = { version = "0.4", features = ["std", "kv_unstable"] }
-//! captains_log = "0.4"
+//! captains_log = "0.5"
 //! ```
 //!
 //! lib.rs or main.rs:
 //! ``` rust
+//! // By default, reexport the macros from log crate
 //! #[macro_use]
 //! extern crate captains_log;
-//! #[macro_use]
-//! extern crate log;
+//!
 //! ```
 //!
 //! ## Production example
@@ -98,6 +98,17 @@
 //! config.build();
 //! ```
 //!
+//! ## Configure by environment
+//!
+//! There is a recipe [env_logger()](crate::recipe::env_logger()) to configure a file logger or
+//! console logger from env. As simple as:
+//!
+//! ``` rust
+//! use captains_log::recipe;
+//! let _ = recipe::env_logger("LOG_FILE", "LOG_LEVEL").build();
+//! ```
+//!
+//! If you want to custom more, setup your config with [env_or] helper.
 //!
 //! ## Fine-grain module-level control
 //!
@@ -194,7 +205,6 @@
 //! ``` rust
 //!
 //! use rstest::*;
-//! use log::*;
 //! use captains_log::*;
 //!
 //! // A show case that setup() fixture will be called twice, before each test.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,12 @@
 //! Refer to [recipe] module for more example.
 //!
 //! ``` rust
-//! use log::{debug, info, error};
-//! use captains_log::recipe::split_error_file_logger;
+//! #[macro_use]
+//! extern crate captains_log;
+//! use captains_log::recipe;
 //!
 //! // You'll get /tmp/test.log with all logs, and /tmp/test.log.wf only with error logs.
-//! let mut log_builder = split_error_file_logger("/tmp", "test", log::Level::Debug);
+//! let mut log_builder = recipe::split_error_file_logger("/tmp", "test", log::Level::Debug);
 //! // Builder::build() is equivalent of setup_log().
 //! log_builder.build();
 //!
@@ -271,6 +272,9 @@ mod log_filter;
 
 pub use self::{config::*, formatter::FormatRecord, log_filter::*, log_impl::setup_log};
 pub use captains_log_helper::logfn;
+
+pub use log::{Level, LevelFilter};
+pub use log::{debug, error, info, trace, warn};
 
 #[cfg(test)]
 mod tests;

--- a/src/log_filter.rs
+++ b/src/log_filter.rs
@@ -93,7 +93,7 @@ impl log::kv::Source for LogFilter {
 ///     let req_id = r.key("req_id");
 ///     format!("[{time}][{level}][{file}:{line}] {msg}{req_id}\n").to_string()
 /// }
-/// let mut builder = recipe::raw_file_logger_custom("/tmp", "log_filter", log::Level::Debug,
+/// let mut builder = recipe::raw_file_logger_custom("/tmp/log_filter.log", log::Level::Debug,
 ///     recipe::DEFAULT_TIME, debug_format_req_id_f);
 /// builder.dynamic = true;
 ///

--- a/src/tests/test_log_filter.rs
+++ b/src/tests/test_log_filter.rs
@@ -53,8 +53,7 @@ fn test_logger_filter_kv() {
         format!("[{time}][{level}][{file}:{line}] {msg}{req_id}\n").to_string()
     }
     let mut builder = recipe::raw_file_logger_custom(
-        "/tmp",
-        "log_filter",
+        "/tmp/log_filter.log",
         Level::Debug,
         recipe::DEFAULT_TIME,
         debug_format_req_id_f,


### PR DESCRIPTION
### Added

- Support configure from environment with env_or(), and recipe::env_logger().

### Changed

- Change recipe raw_file_logger() & raw_file_custom_logger(), user need to speicified the full path

- Change the definition of LogRawFile to support path/str/String/env_or.
