### PR TITLE
v0.8.0: Add RingFile sink and change a few API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Remove Builder::add_XXX functions, replace them with add_sink()
-
 ### Fixed
+
+## [0.8.0] 2025-08-03
+
+### Added
+
+- Add LogSinkTrait::open(), to be distinguish with reopen().
+
+- Add RingFile sink as a debugging tool for deadlock
+
+- Re-export signal_consts for convenience
+
+### Changed
+
+- Remove Builder::add_XXX functions, replace them with add_sink()
 
 ## [0.7.0] 2025-07-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "captains-log"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2018"
 authors = ["plan <frostyplanet@gmail.com>"]
 categories = ["development-tools::debugging"]
@@ -31,10 +31,12 @@ crossfire = "2.0"
 file-rotate = "0.8"
 flate2 = "1.0"
 syslog = { version = "7.0", optional = true }
+ring-file = { version = "0.1", optional = true}
 
 [features]
 default = []
 syslog = ["dep:syslog"]
+ringfile=["dep:ring-file"]
 
 [dev-dependencies]
 fmutex = "0"

--- a/src/buf_file_impl.rs
+++ b/src/buf_file_impl.rs
@@ -190,6 +190,10 @@ impl LogSinkBufFile {
 }
 
 impl LogSinkTrait for LogSinkBufFile {
+    #[inline]
+    fn open(&self) -> std::io::Result<()> {
+        self.reopen()
+    }
     fn reopen(&self) -> std::io::Result<()> {
         let _ = self.tx.send(Msg::Reopen);
         Ok(())

--- a/src/console_impl.rs
+++ b/src/console_impl.rs
@@ -106,6 +106,10 @@ impl LogSinkConsole {
 }
 
 impl LogSinkTrait for LogSinkConsole {
+    fn open(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
     fn reopen(&self) -> std::io::Result<()> {
         Ok(())
     }

--- a/src/file_impl.rs
+++ b/src/file_impl.rs
@@ -111,6 +111,11 @@ impl LogSinkFile {
 }
 
 impl LogSinkTrait for LogSinkFile {
+    #[inline]
+    fn open(&self) -> std::io::Result<()> {
+        self.reopen()
+    }
+
     fn reopen(&self) -> std::io::Result<()> {
         match open_file(&self.path) {
             Ok(f) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,14 @@
 //!
 //!     + [LogBufFile]:  Write to log file with merged I/O and delay flush, and optional self-rotation.
 //!
-//!     + [Syslog]: (**feature** `syslog`) Write to local or remote syslog server, with timeout and auto reconnect.
+//!     + [Syslog]: (**feature** `syslog`)
+//!
+//!         Write to local or remote syslog server, with timeout and auto reconnect.
+//!
+//!     + [LogRingFile]: (**feature** `ringfile`)
+//!
+//!         For deadlock / race condition debugging,
+//!         collect log to ring buffer in memory. See the doc of [LogRingFile] for how to use.
 //!
 //! * Log panic message by default.
 //!
@@ -303,13 +310,21 @@ mod file_impl;
 mod formatter;
 mod log_impl;
 mod rotation;
+mod time;
+
 #[cfg(feature = "syslog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "syslog")))]
 mod syslog;
-mod time;
 #[cfg(feature = "syslog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "syslog")))]
 pub use self::syslog::*;
+
+#[cfg(feature = "ringfile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ringfile")))]
+mod ring;
+#[cfg(feature = "ringfile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ringfile")))]
+pub use self::ring::*;
 
 pub mod macros;
 pub mod parser;
@@ -325,8 +340,14 @@ pub use self::rotation::*;
 pub use self::{config::*, formatter::FormatRecord, log_filter::*, log_impl::setup_log};
 pub use captains_log_helper::logfn;
 
+/// Re-export log::Level:
+pub use log::Level;
+/// Re-export log::LevelFilter:
+pub use log::LevelFilter;
 pub use log::{debug, error, info, trace, warn};
-pub use log::{Level, LevelFilter};
+
+/// Re-export from signal_hook::consts:
+pub use signal_hook::consts::signal as signal_consts;
 
 #[cfg(test)]
 mod tests;

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -224,3 +224,23 @@ pub fn syslog_local(max_level: Level) -> Builder {
     let syslog = crate::Syslog::new(Facility::LOG_USER, max_level);
     return Builder::default().add_sink(syslog);
 }
+
+/// Initialize a ring buffer to hold the log. For complete usage, refer to the description of [LogRingFile].
+///
+/// # Arguments:
+///
+/// - `file_path`: path on disk to which the log content will be dumped
+///
+/// - `buf_size`: the size of memory of ring buffer. limit: 0 < buf_size < i32::MAX
+///
+/// - `max_level`: filter the log by level.
+///
+/// - `dump_signal`: Dump the content from memory buffer to disk when the signal received.
+#[cfg(feature = "ringfile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ringfile")))]
+pub fn ring_file<P: Into<PathBuf>>(
+    file_path: P, buf_size: i32, max_level: Level, dump_signal: i32,
+) -> Builder {
+    let ring = crate::LogRingFile::new(file_path, buf_size, max_level, LOG_FORMAT_DEBUG);
+    return Builder::default().signal(dump_signal).add_sink(ring);
+}

--- a/src/ring.rs
+++ b/src/ring.rs
@@ -1,0 +1,162 @@
+use crate::{
+    config::{LogFormat, SinkConfigBuild, SinkConfigTrait},
+    log_impl::{LogSink, LogSinkTrait},
+    time::Timer,
+};
+use log::*;
+use ring_file::*;
+
+use std::cell::UnsafeCell;
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+use std::mem::transmute;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// The LogRingFile sink is a tool for debugging deadlock or race condition,
+/// when the problem cannot be reproduce with ordinary log (because disk I/O will slow down the
+/// execution and prevent the bug to occur).
+///
+/// # Usage
+///
+/// Enable feature `ringfile` in your Cargo.toml.
+///
+/// Replace the log setup with the following in your test case:
+/// ``` rust
+/// use captains_log::*;
+/// recipe::ring_file("/tmp/ring.log", 512*1024*1024, Level::Info,
+///     signal_consts::SIGHUP).test().build().expect("log setup");
+/// ```
+///
+/// Then add some high-level log to critical path in the code, try to reproduce the problem, and
+/// reduce the amount of log if the bug not occur.
+///
+/// On start-up, it will create a limited-size ring-buffer-like memory. The log content will be hold within memory but
+/// not written to disk, old logs will be overwritten by new ones. Until specified signal arrives, the last
+/// part of log message will be dumped to file, in time order.
+///
+/// Once your program hangs up completely , find your process pid and send a signal to it.
+///
+/// ``` shell
+/// kill -SIGHUP <pid>
+/// ```
+/// There will be messages print to stdout:
+///
+/// ``` text
+/// RingFile: start dumping
+/// RingFile: dump complete
+/// ```
+///
+/// Then you can inspect your log content on disk (for this example `/tmp/ring.log`).
+///
+/// The backend is provided by [RingFile crate](https://docs.rs/ring-file). To ensure low
+/// latency, the buffer is protected by a spinlock instead of a mutex. After the program hangs, because
+/// no more message will be written to the buffer, log content can be safely copied from the buffer area to disk.
+///
+/// A real-life debugging story can be found on <https://github.com/frostyplanet/crossfire-rs/issues/24>.
+#[derive(Hash)]
+pub struct LogRingFile {
+    pub file_path: Box<Path>,
+    pub level: Level,
+    pub format: LogFormat,
+    /// 0 < buf_size < i32::MAX
+    pub buf_size: i32,
+}
+
+impl LogRingFile {
+    pub fn new<P: Into<PathBuf>>(
+        file_path: P, buf_size: i32, max_level: Level, format: LogFormat,
+    ) -> Self {
+        assert!(buf_size > 0);
+        Self { buf_size, file_path: file_path.into().into_boxed_path(), level: max_level, format }
+    }
+}
+
+impl SinkConfigBuild for LogRingFile {
+    fn build(&self) -> LogSink {
+        LogSink::RingFile(LogSinkRingFile::new(self))
+    }
+}
+
+impl SinkConfigTrait for LogRingFile {
+    fn get_level(&self) -> Level {
+        self.level
+    }
+
+    fn get_file_path(&self) -> Option<Box<Path>> {
+        Some(self.file_path.clone())
+    }
+
+    fn write_hash(&self, hasher: &mut Box<dyn Hasher>) {
+        self.hash(hasher);
+        hasher.write(b"LogRingFile");
+    }
+}
+
+pub(crate) struct LogSinkRingFile {
+    max_level: Level,
+    inner: UnsafeCell<RingFile>,
+    formatter: LogFormat,
+    /// In order to be fast, use a spin lock instead of Mutex
+    locked: AtomicBool,
+}
+
+unsafe impl Send for LogSinkRingFile {}
+unsafe impl Sync for LogSinkRingFile {}
+
+impl LogSinkRingFile {
+    fn new(config: &LogRingFile) -> Self {
+        Self {
+            max_level: config.level,
+            inner: UnsafeCell::new(RingFile::new(config.buf_size, config.file_path.to_path_buf())),
+            formatter: config.format.clone(),
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    #[inline(always)]
+    fn get_inner(&self) -> &RingFile {
+        unsafe { transmute(self.inner.get()) }
+    }
+
+    #[inline(always)]
+    fn get_inner_mut(&self) -> &mut RingFile {
+        unsafe { transmute(self.inner.get()) }
+    }
+}
+
+impl LogSinkTrait for LogSinkRingFile {
+    fn open(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn reopen(&self) -> std::io::Result<()> {
+        println!("RingFile: start dumping");
+        if let Err(e) = self.get_inner().dump() {
+            println!("RingFile: dump error {:?}", e);
+            Err(e)
+        } else {
+            println!("RingFile: dump complete");
+            Ok(())
+        }
+    }
+
+    #[inline(always)]
+    fn log(&self, now: &Timer, r: &Record) {
+        if r.level() <= self.max_level {
+            let buf = self.formatter.process(now, r);
+            while self
+                .locked
+                .compare_exchange_weak(false, true, Ordering::SeqCst, Ordering::Relaxed)
+                .is_err()
+            {
+                std::hint::spin_loop();
+            }
+            let _ = self.get_inner_mut().write_all(buf.as_bytes());
+            self.locked.store(false, Ordering::Release);
+        }
+    }
+
+    #[inline(always)]
+    fn flush(&self) {}
+}

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -235,6 +235,10 @@ impl LogSinkSyslog {
 }
 
 impl LogSinkTrait for LogSinkSyslog {
+    fn open(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+
     fn reopen(&self) -> std::io::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Incorporate https://github.com/NaturalIO/ring-file  into captains-log.

### Added

- Add LogSinkTrait::open(), to be distinguish with reopen().

- Add RingFile sink as a debugging tool for deadlock

- Re-export signal_consts for convenience

### Changed

- Remove Builder::add_XXX functions, replace them with add_sink()
